### PR TITLE
prepare composables

### DIFF
--- a/src/runtime/composables/useFlyoConfig.ts
+++ b/src/runtime/composables/useFlyoConfig.ts
@@ -1,0 +1,14 @@
+import { useRoute, inject } from '#imports'
+
+/**
+ * Resolves the current page route
+ * 
+ * todo: type hinting
+ */
+export const useFlyoConfig = (): Object => {
+  const { config } = inject('flyo')
+
+  return {
+    config
+  }
+}

--- a/src/runtime/composables/useFlyoCurrentPage.ts
+++ b/src/runtime/composables/useFlyoCurrentPage.ts
@@ -2,13 +2,15 @@ import { useRoute, inject } from '#imports'
 
 /**
  * Resolves the current page route
+ * 
+ * todo: type hinting
  */
-export const useFlyoCurrentPage = (): Object => {
+export const useFlyoCurrentPage = async (): Promise<Object> => {
   const { page } = inject('flyo')
   const { fetch } = page
 
   const route = useRoute()
-  fetch(route.path)
+  await fetch(route.path)
 
   return {
     ...page

--- a/src/runtime/composables/useFlyoEntity.ts
+++ b/src/runtime/composables/useFlyoEntity.ts
@@ -1,0 +1,17 @@
+import { useRoute, inject } from '#imports'
+
+/**
+ * Resolves the current page route
+ * 
+ * todo: type hinting
+ */
+export const useFlyoEntity = async (uniqueid:string): Promise<Object> => {
+  const { entity } = inject('flyo')
+  const { fetch } = entity
+
+  await fetch(uniqueid)
+
+  return {
+    ...entity
+  }
+}


### PR DESCRIPTION
- 2x new async composables for page and entity resolver
- none async comosable for config

wyh composables? 

+ they are auto imported into nuxt, which means the IDE will help with auto complete
+ async setup helps when using nuxt features like: loading indicator, error page handling

Todos?

- [ ] The composable should return the correct object, this makes developer experience even batter knowing there is a `response` property 
- [ ] There should be also a composable for page resolver without router, this can be usefulle when not the `useFlyoCurrentPage` is used